### PR TITLE
SSO Endpoint for discourse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /node_modules
 /logs/*
 /dev_db/*
+/static/user_uploads/*

--- a/cshub_site/settings.py
+++ b/cshub_site/settings.py
@@ -9,6 +9,9 @@ except:
     
 main_path = secrets['MAIN_PATH']
 
+DISCOURSE_BASE_URL = secrets['DISCOURSE_BASE_URL']
+DISCOURSE_SSO_SECRET = secrets['DISCOURSE_SSO_SECRET']
+
 DEBUG = (secrets['DEBUG'] == "TRUE")
 TEMPLATE_DEBUG = DEBUG
 

--- a/cshub_site/templates/login.html
+++ b/cshub_site/templates/login.html
@@ -16,7 +16,9 @@
 		<input type="text" name="username" value="" id="username"> 
 		<label for="password">Password:</label>
 		<input type="password" name="password" value="" id="password">
-
+		{% if next %}
+			<input type="hidden" name="next" value="{{ next }}">
+		{% endif %}
 		<input type="submit" class="btn btn-info" value="login">
 	</form>
 </div>

--- a/cshub_site/urls.py
+++ b/cshub_site/urls.py
@@ -7,6 +7,7 @@ admin.autodiscover()
 urlpatterns = patterns('',
 	(r'^events/', include('event_app.urls')),
     (r'^accounts/', include('userprofile.urls')),
+    (r'^discourse/', include('discourse.urls')),
     url(r'^admin/', include(admin.site.urls)),
     
     url(r'^$', 'cshub_site.views.home'), 

--- a/cshub_site/views.py
+++ b/cshub_site/views.py
@@ -157,6 +157,8 @@ def register_user(request):
 
 			if request.is_ajax():
 				registration_form.save()
+				if not settings.DEBUG: 
+					send_mail('NEW USER SIGNUP', registration_form.cleaned_data['username'], 'newuser@example.com', ['mlisbit@gmail.com'], fail_silently=False)
 				user = auth.authenticate(username=registration_form.cleaned_data.get('username'), password=registration_form.cleaned_data.get('password2'))
 				auth.login(request, user)
 				user_logger.info('NEW USER: '+request.user.username)

--- a/discourse/admin.py
+++ b/discourse/admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+# Register your models here.

--- a/discourse/models.py
+++ b/discourse/models.py
@@ -1,0 +1,3 @@
+from django.db import models
+
+# Create your models here.

--- a/discourse/tests.py
+++ b/discourse/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/discourse/urls.py
+++ b/discourse/urls.py
@@ -1,0 +1,5 @@
+from django.conf.urls import patterns, include, url
+
+urlpatterns = patterns('',
+    url(r'^sso/$', 'discourse.views.sso'),
+)

--- a/discourse/views.py
+++ b/discourse/views.py
@@ -1,0 +1,63 @@
+from django.shortcuts import render
+
+
+import base64
+import hmac
+import hashlib
+import urllib
+import json
+
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseBadRequest, HttpResponseRedirect, HttpResponseForbidden, HttpResponse
+from django.conf import settings
+
+@login_required
+def sso(request):
+	if None in [settings.DISCOURSE_SSO_SECRET, settings.DISCOURSE_BASE_URL]:
+		return HttpResponseForbidden('SSO is not enabled in site configuration.')
+	
+	payload = request.GET.get('sso')
+	signature = request.GET.get('sig')
+
+	if None in [payload, signature]:
+		return HttpResponseBadRequest('No SSO payload or signature.')
+
+	## Validate the payload
+
+	try:
+		payload = urllib.unquote(payload)
+		assert 'nonce' in base64.decodestring(payload)
+		assert len(payload) > 0
+	except AssertionError:
+		return HttpResponseBadRequest('Invalid payload..')
+
+	key = settings.DISCOURSE_SSO_SECRET
+	h = hmac.new(key, payload, digestmod=hashlib.sha256)
+	this_signature = h.hexdigest()
+
+	if this_signature != signature:
+		return HttpResponseBadRequest('Payload does not match signature.')
+
+	## Build the return payload
+
+	params = {
+		'nonce': base64.decodestring(payload).split('=')[1],
+		'email': request.user.email,
+		'external_id': request.user.id,
+		'username': request.user.username
+	}
+
+	if request.user.first_name and request.user.last_name:
+		params['name'] = '%s %s' %(request.user.first_name, request.user.last_name)
+
+	if request.user.profile.user_avatar.name:
+		params['avatar_url'] = request.build_absolute_uri('/static/' + request.user.profile.user_avatar.url)
+	#return HttpResponse(json.dumps(params))
+	return_payload = base64.encodestring(urllib.urlencode(params))
+	h = hmac.new(key, return_payload, digestmod=hashlib.sha256)
+	query_string = urllib.urlencode({'sso': return_payload, 'sig': h.hexdigest()})
+
+	## Redirect back to Discourse
+
+	url = '%s/session/sso_login' % settings.DISCOURSE_BASE_URL
+	return HttpResponseRedirect('%s?%s' % (url, query_string))

--- a/secrets_example.json
+++ b/secrets_example.json
@@ -24,6 +24,9 @@
 
 	"LOG_DIR":"logs/",
 
+	"DISCOURSE_BASE_URL": "",
+	"DISCOURSE_SSO_SECRET": "",
+
 	"EMAIL_TO": [
 		"example@example.com"
 	]


### PR DESCRIPTION
- Adds new app 'discourse' exposing endpoint '/discourse/sso' which performs authentication and calls back the discourse server with user information. (id, username, email, name and avatar)
- Adds new hidden parameter 'next' to auth_view to facilitate the redirect
- Removed unreachable code in views.login
- Removed call to send email to maciej on new user creation (even on dev) - This could be handled better 
- Added 'DISCOURSE_BASE_URL' and 'DISCOURSE_SSO_SECRET' to secret.

I will merge this to the new branch. ~~once @mlisbit gives me access.~~ 

_Discussion and feed back only. DONT PULL UPSTREAM_ 
